### PR TITLE
Fix/coco segmentation

### DIFF
--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -146,8 +146,8 @@ class CocoDataset(CustomDataset):
         """Parse bbox and mask annotation.
 
         Args:
+            img_info (dict): Image info.
             ann_info (list[dict]): Annotation info of an image.
-            with_mask (bool): Whether to parse mask annotations.
 
         Returns:
             dict: A dict containing the following keys: bboxes, bboxes_ignore,\

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -176,7 +176,8 @@ class CocoDataset(CustomDataset):
             else:
                 gt_bboxes.append(bbox)
                 gt_labels.append(self.cat2label[ann['category_id']])
-                gt_masks_ann.append(ann.get('segmentation', None))
+                if ann.get('segmentation', None) is not None:
+                    gt_masks_ann.append(ann['segmentation'])
 
         if gt_bboxes:
             gt_bboxes = np.array(gt_bboxes, dtype=np.float32)


### PR DESCRIPTION
When an image has bboxes but no masks, the `_parse_ann_info` method of `CocoDataset` appends None for gt_masks. This makes the method `_poly2mask` of `LoadAnnotations` fail at line 308 of file `mmdet.datasets.pipelines.loading.py`.