### PR TITLE
Update dependency from `sklearn` to `scikit-learn`

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,4 @@
 cityscapesscripts
 imagecorruptions
 scipy
-sklearn
+scikit-learn


### PR DESCRIPTION
The `sklearn` package in PyPI has been deprecated in favor of `scikit-learn`. 