### PR TITLE
🐛 Bugfix: Add pip [fairscale, scipy, yapf]

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,10 @@ RUN conda clean --all
 RUN pip install openmim
 RUN pip install timm
 RUN mim install mmdet==2.25.3
+RUN pip install fairscale==0.4.13
+RUN pip install scipy==1.10.1
+
+# Install etc.
+RUN pip install yapf==0.40.1
 
 WORKDIR /Co-DETR
-


### PR DESCRIPTION
## ISSUE
When building the Dockerfile from the repository and proceeding with training according to the "Train Co-Deformable-DETR + ResNet-50" Guide, an error occurs stating that three Python packages are not installed.

Below are the logs of the errors that occurred.

### 1. fairscale not pip install

__ERROR MSG__:
```  File "/home/mmdet/models/utils/__init__.py", line 19, in <module>
    import fairscale
ModuleNotFoundError: No module named 'fairscale'
```

### 2. scipy not pip install

__ERROR MSG__:
```  File "/home/mmdet/core/bbox/assigners/hungarian_assigner.py", line 131, in assign
    raise ImportError('Please run "pip install scipy" '
ImportError: Please run "pip install scipy" to install scipy first.
```

### 3. yapf not pip install

__ERROR MSG__:
```  File "/opt/conda/lib/python3.8/site-packages/mmcv/utils/config.py", line 502, in pretty_text
    text, _ = FormatCode(text, style_config=yapf_style, verify=True)
TypeError: FormatCode() got an unexpected keyword argument 'verify'
```

Therefore, I have added the necessary Python packages to the Dockerfile.
Now, you can proceed with the training immediately after building the Dockerfile.